### PR TITLE
[FEAT] 캔버스에 노트 추가 툴바 도입

### DIFF
--- a/src/features/canvas/components/Canvas/Canvas.module.scss
+++ b/src/features/canvas/components/Canvas/Canvas.module.scss
@@ -1,5 +1,6 @@
 // Override React Flow CSS variables with our design tokens
 .wrapper {
+  position: relative;
   width: 100%;
   height: 100%;
 
@@ -21,8 +22,7 @@
   --xy-node-border-default: 1px solid var(--color-canvas-node-border);
   --xy-node-border-radius-default: var(--radius-md);
   --xy-node-boxshadow-hover-default: var(--shadow-md);
-  --xy-node-boxshadow-selected-default: 0 0 0 2px
-    var(--color-canvas-node-selected);
+  --xy-node-boxshadow-selected-default: 0 0 0 2px var(--color-canvas-node-selected);
 
   // Handle
   --xy-handle-background-color-default: var(--color-canvas-handle);
@@ -38,9 +38,7 @@
 
   // Controls
   --xy-controls-button-background-color-default: var(--color-bg-surface);
-  --xy-controls-button-background-color-hover-default: var(
-    --color-interactive-secondary-hover
-  );
+  --xy-controls-button-background-color-hover-default: var(--color-interactive-secondary-hover);
   --xy-controls-button-border-color-default: var(--color-border-default);
   --xy-controls-box-shadow-default: var(--shadow-md);
 

--- a/src/features/canvas/components/Canvas/Canvas.tsx
+++ b/src/features/canvas/components/Canvas/Canvas.tsx
@@ -5,13 +5,14 @@ import {
   ReactFlow,
   type NodeMouseHandler,
   type ReactFlowInstance,
-} from "@xyflow/react";
-import "@xyflow/react/dist/style.css";
-import { useCallback, useRef } from "react";
-import { useCanvasStore } from "../../stores/canvasStore";
-import { nodeTypes } from "../../nodeTypes";
-import { edgeTypes } from "../../edgeTypes";
-import styles from "./Canvas.module.scss";
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useCallback, useRef } from 'react';
+import { useCanvasStore } from '../../stores/canvasStore';
+import { nodeTypes } from '../../nodeTypes';
+import { edgeTypes } from '../../edgeTypes';
+import { Toolbar } from '../Toolbar/Toolbar';
+import styles from './Canvas.module.scss';
 
 export const Canvas = () => {
   const nodes = useCanvasStore((s) => s.nodes);
@@ -22,6 +23,7 @@ export const Canvas = () => {
   const addNode = useCanvasStore((s) => s.addNode);
   const setSelectedNodeId = useCanvasStore((s) => s.setSelectedNodeId);
   const rfInstance = useRef<ReactFlowInstance | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_, node) => {
@@ -34,9 +36,19 @@ export const Canvas = () => {
     setSelectedNodeId(null);
   }, [setSelectedNodeId]);
 
+  const onAddNote = useCallback(() => {
+    if (!rfInstance.current || !wrapperRef.current) return;
+    const rect = wrapperRef.current.getBoundingClientRect();
+    const position = rfInstance.current.screenToFlowPosition({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    });
+    addNode('note', position, { text: '' });
+  }, [addNode]);
+
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
+    event.dataTransfer.dropEffect = 'copy';
   }, []);
 
   const onDrop = useCallback(
@@ -52,10 +64,10 @@ export const Canvas = () => {
         });
         const fileUrl = URL.createObjectURL(file);
 
-        if (file.type === "application/pdf") {
-          addNode("document", position, { fileName: file.name, fileUrl });
-        } else if (file.type.startsWith("image/")) {
-          addNode("image", position, { fileName: file.name, fileUrl });
+        if (file.type === 'application/pdf') {
+          addNode('document', position, { fileName: file.name, fileUrl });
+        } else if (file.type.startsWith('image/')) {
+          addNode('image', position, { fileName: file.name, fileUrl });
         }
       });
     },
@@ -63,7 +75,7 @@ export const Canvas = () => {
   );
 
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} ref={wrapperRef}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -80,12 +92,13 @@ export const Canvas = () => {
         onDragOver={onDragOver}
         onDrop={onDrop}
         fitView
-        deleteKeyCode={["Backspace", "Delete"]}
+        deleteKeyCode={['Backspace', 'Delete']}
         connectionRadius={50}
       >
         <Background variant={BackgroundVariant.Dots} />
         <Controls />
       </ReactFlow>
+      <Toolbar onAddNote={onAddNote} />
     </div>
   );
 };

--- a/src/features/canvas/components/Toolbar/Toolbar.module.scss
+++ b/src/features/canvas/components/Toolbar/Toolbar.module.scss
@@ -1,0 +1,34 @@
+.toolbar {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  z-index: 10;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &:hover {
+    background: var(--color-interactive-secondary-hover);
+    box-shadow: var(--shadow-md);
+  }
+
+  &:active {
+    background: var(--color-interactive-secondary-active);
+  }
+}

--- a/src/features/canvas/components/Toolbar/Toolbar.tsx
+++ b/src/features/canvas/components/Toolbar/Toolbar.tsx
@@ -1,0 +1,13 @@
+import styles from './Toolbar.module.scss';
+
+interface ToolbarProps {
+  onAddNote: () => void;
+}
+
+export const Toolbar = ({ onAddNote }: ToolbarProps) => (
+  <div className={styles.toolbar}>
+    <button className={styles.button} onClick={onAddNote} title="노트 추가">
+      Note
+    </button>
+  </div>
+);


### PR DESCRIPTION
## Summary

- What changed in this PR?
  - 캔버스 좌측 상단에 `Toolbar` 컴포넌트를 추가하고 `Note` 버튼으로 노트 노드를 생성할 수 있게 했습니다.
  - `Canvas`에서 React Flow 인스턴스와 wrapper DOM을 함께 참조해 현재 뷰포트 중앙 좌표를 계산한 뒤, 해당 위치에 빈 노트 노드를 추가하도록 연결했습니다.
  - 툴바를 캔버스 위에 오버레이하기 위해 wrapper를 `position: relative`로 조정하고, 버튼 스타일을 디자인 토큰에 맞춰 구성했습니다.

- Why was this change needed?
  - 이슈 #11의 요구사항인 "버튼 또는 우클릭으로 새 노트 노드 생성"을 충족하기 위해, 사용자가 드래그 앤 드롭 없이 즉시 노트를 생성할 수 있는 진입점을 제공해야 했습니다.

## Linked Issue

- Closes #11

## Branch Rule Check

- [x] Branch follows `<type>/<issue-number>-<slug>` (example: `feat/123-login-page`)

## Scope Check (1 Feature = 1 Issue = 1 PR)

- [x] This PR addresses a single issue
- [x] Unrelated changes are excluded

## Validation

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`

## Risk and Rollback

- Risk:
  - 툴바가 캔버스 좌측 상단에 고정되어 있어, 추후 다른 오버레이 UI와 위치 충돌이 생길 수 있습니다.
  - 노트 생성 위치를 현재 보이는 캔버스 중앙으로 계산하므로, 사용자가 기대하는 생성 위치 정책과 다를 수 있습니다.
- Rollback plan:
  - `Toolbar` 컴포넌트와 `Canvas`의 `onAddNote` 연결, wrapper 레이아웃 변경을 되돌리면 기존 드래그 앤 드롭 기반 캔버스 동작으로 복구됩니다.

## Screenshots (Optional)
<img width="1273" height="1287" alt="스크린샷 2026-03-15 오전 5 51 52" src="https://github.com/user-attachments/assets/669c468b-66b0-40ae-b5e1-fe9300099b0a" />
<img width="1273" height="1287" alt="스크린샷 2026-03-15 오전 5 52 29" src="https://github.com/user-attachments/assets/d9d8e5f8-f813-4da7-b14d-92a8d5c3bb2b" />
