### PR TITLE
fix: 캔버스 우클릭 메뉴 위치를 화면 안으로 보정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ docs/til/*
 .claude/*
 .gemini/*
 .codex/*
+.junie/*

--- a/src/features/canvas/components/Canvas/Canvas.tsx
+++ b/src/features/canvas/components/Canvas/Canvas.tsx
@@ -132,7 +132,7 @@ export const Canvas = () => {
         <CanvasContextMenu
           x={contextMenu.screenX}
           y={contextMenu.screenY}
-          onAddNote={onContextMenuAddNote}
+          items={[{ label: '노트 추가', onClick: onContextMenuAddNote }]}
           onClose={() => setContextMenu(null)}
         />
       )}

--- a/src/features/canvas/components/CanvasContextMenu/CanvasContextMenu.tsx
+++ b/src/features/canvas/components/CanvasContextMenu/CanvasContextMenu.tsx
@@ -1,15 +1,40 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import styles from './CanvasContextMenu.module.scss';
+
+export interface ContextMenuItem {
+  label: string;
+  onClick: () => void;
+}
 
 interface CanvasContextMenuProps {
   x: number;
   y: number;
-  onAddNote: () => void;
+  items: ContextMenuItem[];
   onClose: () => void;
 }
 
-export const CanvasContextMenu = ({ x, y, onAddNote, onClose }: CanvasContextMenuProps) => {
+const VIEWPORT_PADDING = 8;
+
+export const CanvasContextMenu = ({ x, y, items, onClose }: CanvasContextMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ x, y });
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const { width, height } = menu.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const clampedX = Math.min(x, viewportWidth - width - VIEWPORT_PADDING);
+    const clampedY = Math.min(y, viewportHeight - height - VIEWPORT_PADDING);
+
+    setPosition({
+      x: Math.max(VIEWPORT_PADDING, clampedX),
+      y: Math.max(VIEWPORT_PADDING, clampedY),
+    });
+  }, [x, y]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -31,16 +56,19 @@ export const CanvasContextMenu = ({ x, y, onAddNote, onClose }: CanvasContextMen
   }, [onClose]);
 
   return (
-    <div ref={menuRef} className={styles.menu} style={{ top: y, left: x }}>
-      <button
-        className={styles.item}
-        onClick={() => {
-          onAddNote();
-          onClose();
-        }}
-      >
-        노트 추가
-      </button>
+    <div ref={menuRef} className={styles.menu} style={{ top: position.y, left: position.x }}>
+      {items.map((item) => (
+        <button
+          key={item.label}
+          className={styles.item}
+          onClick={() => {
+            item.onClick();
+            onClose();
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- 캔버스 우클릭 메뉴가 화면 경계를 벗어날 때 뷰포트 안쪽으로 자동 보정되도록 수정했습니다.
- `CanvasContextMenu`를 단일 `onAddNote` 콜백 대신 `ContextMenuItem[]` 기반 구조로 바꿔 향후 메뉴 액션 확장이 가능하도록 정리했습니다.
- 개발 보조 도구 디렉터리인 `.junie/`를 `.gitignore`에 추가했습니다.

## Linked Issue

- Closes #15

## Branch Rule Check

- [ ] Branch follows `<type>/<issue-number>-<slug>` (example: `feat/123-login-page`)

## Scope Check (1 Feature = 1 Issue = 1 PR)

- [ ] This PR addresses a single issue
- [ ] Unrelated changes are excluded

## Validation

- [ ] `pnpm run lint`
- [ ] `pnpm run typecheck`
- [ ] `pnpm run build`

## Risk and Rollback

- Risk:
  - 메뉴 크기 측정 시점이 바뀌면서 초기 렌더 직후 위치가 조정되므로, 브라우저별 레이아웃 차이에 따라 드물게 위치가 한 번 더 이동해 보일 수 있습니다.
  - `.gitignore` 변경은 기능 영향은 없지만 이번 이슈 범위와는 직접 관련이 적습니다.
- Rollback plan:
  - `CanvasContextMenu`의 위치 보정 로직과 `items` 구조 변경을 되돌리고 기존 고정 위치 렌더링으로 복구합니다.
  - 필요하면 `.gitignore`의 `.junie/*` 항목만 별도 revert 합니다.

## Screenshots (Optional)
