### PR TITLE
feat: 인증 상태 기반 라우트 가드와 로그아웃 흐름 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { ProtectedRoute, PublicRoute } from '../features/auth';
 import { CanvasPage, LoginPage, SignupPage } from '../pages';
 
 const queryClient = new QueryClient();
@@ -8,9 +9,13 @@ export const App = () => (
   <QueryClientProvider client={queryClient}>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<CanvasPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/signup" element={<SignupPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<CanvasPage />} />
+        </Route>
+        <Route element={<PublicRoute />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   </QueryClientProvider>

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthStore } from '../../../shared/stores/authStore';
+
+export const ProtectedRoute = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/src/features/auth/components/PublicRoute.tsx
+++ b/src/features/auth/components/PublicRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthStore } from '../../../shared/stores/authStore';
+
+export const PublicRoute = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,3 +1,5 @@
 export { useLogin } from './hooks/useLogin';
+export { ProtectedRoute } from './components/ProtectedRoute';
+export { PublicRoute } from './components/PublicRoute';
 export { useSignup } from './hooks/useSignup';
 export type { LoginRequest, SignupRequest, AuthResponse } from './api/authApi';

--- a/src/features/canvas/components/Canvas/Canvas.tsx
+++ b/src/features/canvas/components/Canvas/Canvas.tsx
@@ -8,6 +8,8 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useCallback, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../../../../shared/stores/authStore';
 import { useCanvasStore } from '../../stores/canvasStore';
 import { nodeTypes } from '../../nodeTypes';
 import { edgeTypes } from '../../edgeTypes';
@@ -23,6 +25,15 @@ export const Canvas = () => {
   const onConnect = useCanvasStore((s) => s.onConnect);
   const addNode = useCanvasStore((s) => s.addNode);
   const setSelectedNodeId = useCanvasStore((s) => s.setSelectedNodeId);
+  const navigate = useNavigate();
+  const userName = useAuthStore((s) => s.user?.name ?? '');
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  const onLogout = useCallback(() => {
+    clearAuth();
+    navigate('/login');
+  }, [clearAuth, navigate]);
+
   const rfInstance = useRef<ReactFlowInstance | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [contextMenu, setContextMenu] = useState<{
@@ -127,7 +138,7 @@ export const Canvas = () => {
         <Background variant={BackgroundVariant.Dots} />
         <Controls />
       </ReactFlow>
-      <Toolbar onAddNote={onAddNote} />
+      <Toolbar onAddNote={onAddNote} userName={userName} onLogout={onLogout} />
       {contextMenu && (
         <CanvasContextMenu
           x={contextMenu.screenX}

--- a/src/features/canvas/components/Toolbar/Toolbar.module.scss
+++ b/src/features/canvas/components/Toolbar/Toolbar.module.scss
@@ -7,6 +7,14 @@
   gap: var(--space-2);
 }
 
+.userName {
+  display: flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
 .button {
   display: flex;
   align-items: center;

--- a/src/features/canvas/components/Toolbar/Toolbar.tsx
+++ b/src/features/canvas/components/Toolbar/Toolbar.tsx
@@ -2,12 +2,18 @@ import styles from './Toolbar.module.scss';
 
 interface ToolbarProps {
   onAddNote: () => void;
+  userName: string;
+  onLogout: () => void;
 }
 
-export const Toolbar = ({ onAddNote }: ToolbarProps) => (
+export const Toolbar = ({ onAddNote, userName, onLogout }: ToolbarProps) => (
   <div className={styles.toolbar}>
     <button className={styles.button} onClick={onAddNote} title="노트 추가">
       Note
+    </button>
+    <span className={styles.userName}>{userName}</span>
+    <button className={styles.button} onClick={onLogout}>
+      로그아웃
     </button>
   </div>
 );


### PR DESCRIPTION
## Summary

  - 인증 상태에 따라 접근을 제어하는 `ProtectedRoute`, `PublicRoute`를 추가하고 앱 라우트에 적용했습니다.
  - 비인증 사용자는 `/` 접근 시 `/login`으로 이동하고, 이미 로그인한 사용자는 `/login`, `/signup` 접근 시 `/`로 리다이렉트되도록 정리했습니다.
  - 캔버스 툴바에 사용자 이름과 로그아웃 버튼을 추가하고, 로그아웃 시 인증 상태를 비운 뒤 `/login`으로 이동하도록 연결했습니다.

  ## Linked Issue

  - Closes #17

  ## Branch Rule Check

  - [x] Branch follows `<type>/<issue-number>-<slug>` (example: `feat/123-login-
  page`)

  ## Scope Check (1 Feature = 1 Issue = 1 PR)

  - [x] This PR addresses a single issue
  - [x] Unrelated changes are excluded

  ## Validation

  - [ ] `pnpm run lint`
  - [ ] `pnpm run typecheck`
  - [ ] `pnpm run build`

  ## Risk and Rollback

  - Risk:
    - 현재 라우트 가드는 `isAuthenticated()`만 기준으로 동작하므로, 만료된 토큰을 가진 상태에서 첫 API 호출 전까지는 인증된 것으로 보일 수 있습니다.
    - 로그아웃은 클라이언트 상태 초기화 중심이라 서버 측 토큰 무효화 정책이 추가 되면 연동 보완이 필요합니다.
  - Rollback plan:
    - `App.tsx`에서 `ProtectedRoute`, `PublicRoute` 적용을 제거하고 기존 직접 라우팅으로 되돌립니다.
    - `Toolbar`의 사용자 이름/로그아웃 UI와 `Canvas.tsx`의 로그아웃 처리 코드를 되돌립니다.
    - `src/features/auth/components/ProtectedRoute.tsx`, `src/features/auth/components/PublicRoute.tsx` 추가분을 제거합니다.

  ## Screenshots (Optional)