### PR TITLE
feat: site 디자인 기준을 반영한 앱 UI 브랜드 정렬

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CastCanvas Lab</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#4F46E5"/>
+  <rect x="6" y="6" width="12" height="12" rx="2" fill="white" fill-opacity="0.9"/>
+  <rect x="14" y="14" width="12" height="12" rx="2" fill="white" fill-opacity="0.5"/>
+</svg>

--- a/src/features/canvas/components/Toolbar/Toolbar.module.scss
+++ b/src/features/canvas/components/Toolbar/Toolbar.module.scss
@@ -1,39 +1,99 @@
+@use '../../../../shared/styles/mixins' as *;
+
 .toolbar {
   position: absolute;
   top: var(--space-3);
   left: var(--space-3);
-  z-index: 10;
+  right: var(--space-3);
+  z-index: var(--z-panel);
   display: flex;
-  gap: var(--space-2);
+  align-items: center;
+  gap: var(--space-1);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2) var(--space-2);
+  height: 44px;
+
+  @include sm {
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+  }
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.brandMark {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.divider {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border-default);
+  flex-shrink: 0;
+  margin: 0 var(--space-1);
+}
+
+.spacer {
+  flex: 1;
 }
 
 .userName {
-  display: flex;
+  display: none;
   align-items: center;
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-secondary);
+  flex-shrink: 0;
+
+  @include md {
+    display: flex;
+  }
 }
 
 .button {
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: var(--space-2) var(--space-3);
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: none;
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
   font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
   cursor: pointer;
   transition:
     background var(--transition-fast),
-    box-shadow var(--transition-fast);
+    border-color var(--transition-fast);
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  @include sm {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  span {
+    display: none;
+
+    @include sm {
+      display: inline;
+    }
+  }
 
   &:hover {
     background: var(--color-interactive-secondary-hover);
-    box-shadow: var(--shadow-md);
+    border-color: var(--color-border-default);
   }
 
   &:active {

--- a/src/features/canvas/components/Toolbar/Toolbar.tsx
+++ b/src/features/canvas/components/Toolbar/Toolbar.tsx
@@ -1,5 +1,36 @@
 import styles from './Toolbar.module.scss';
 
+const PlusIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const LogoutIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+  >
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+);
+
 interface ToolbarProps {
   onAddNote: () => void;
   userName: string;
@@ -8,12 +39,23 @@ interface ToolbarProps {
 
 export const Toolbar = ({ onAddNote, userName, onLogout }: ToolbarProps) => (
   <div className={styles.toolbar}>
+    <div className={styles.brand}>
+      <img src="/logo.svg" alt="" className={styles.brandMark} aria-hidden="true" />
+    </div>
+
+    <div className={styles.divider} />
+
     <button className={styles.button} onClick={onAddNote} title="노트 추가">
-      Note
+      <PlusIcon />
+      <span>노트</span>
     </button>
+
+    <div className={styles.spacer} />
+
     <span className={styles.userName}>{userName}</span>
-    <button className={styles.button} onClick={onLogout}>
-      로그아웃
+    <button className={styles.button} onClick={onLogout} title="로그아웃">
+      <LogoutIcon />
+      <span>로그아웃</span>
     </button>
   </div>
 );

--- a/src/features/inspector/components/Inspector/Inspector.module.scss
+++ b/src/features/inspector/components/Inspector/Inspector.module.scss
@@ -1,13 +1,61 @@
+@use '../../../../shared/styles/mixins' as *;
+
 .panel {
-  width: 320px;
+  width: 100%;
   flex-shrink: 0;
-  height: 100%;
   background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border-subtle);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   z-index: var(--z-panel);
+
+  // Mobile: bottom sheet
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50dvh;
+  border-top: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: var(--shadow-xl);
+  transform: translateY(100%);
+  transition: transform var(--transition-normal);
+
+  &.open {
+    transform: translateY(0);
+  }
+
+  // Desktop: right side panel
+  @include md {
+    position: static;
+    width: 320px;
+    height: 100%;
+    border-top: none;
+    border-left: 1px solid var(--color-border-subtle);
+    border-radius: 0;
+    box-shadow: none;
+    transform: none;
+    transition: none;
+  }
+}
+
+.dragHandle {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-2) 0 var(--space-1);
+  flex-shrink: 0;
+  cursor: grab;
+
+  @include md {
+    display: none;
+  }
+}
+
+.dragHandleBar {
+  width: 36px;
+  height: 4px;
+  background: var(--color-border-strong);
+  border-radius: var(--radius-full);
 }
 
 .empty {

--- a/src/features/inspector/components/Inspector/Inspector.tsx
+++ b/src/features/inspector/components/Inspector/Inspector.tsx
@@ -1,45 +1,45 @@
-import { useCanvasStore } from "../../../canvas";
-import type {
-  DocumentNodeData,
-  ImageNodeData,
-  NoteNodeData,
-} from "../../../canvas/types";
-import { DocumentInspector } from "../DocumentInspector/DocumentInspector";
-import { ImageInspector } from "../ImageInspector/ImageInspector";
-import { NoteInspector } from "../NoteInspector/NoteInspector";
-import styles from "./Inspector.module.scss";
+import { useCanvasStore } from '../../../canvas';
+import type { DocumentNodeData, ImageNodeData, NoteNodeData } from '../../../canvas/types';
+import { DocumentInspector } from '../DocumentInspector/DocumentInspector';
+import { ImageInspector } from '../ImageInspector/ImageInspector';
+import { NoteInspector } from '../NoteInspector/NoteInspector';
+import styles from './Inspector.module.scss';
 
 export const Inspector = () => {
   const selectedNodeId = useCanvasStore((s) => s.selectedNodeId);
   const nodes = useCanvasStore((s) => s.nodes);
 
   const selectedNode = nodes.find((n) => n.id === selectedNodeId) ?? null;
+  const isOpen = selectedNode !== null;
+
+  const panelClass = [styles.panel, isOpen ? styles.open : ''].filter(Boolean).join(' ');
 
   if (!selectedNode) {
     return (
-      <aside className={styles.panel}>
+      <aside className={panelClass}>
+        <div className={styles.dragHandle}>
+          <div className={styles.dragHandleBar} />
+        </div>
         <div className={styles.empty}>
-          <p className={styles.emptyText}>
-            노드를 선택하면 상세 정보가 표시됩니다.
-          </p>
+          <p className={styles.emptyText}>노드를 선택하면 상세 정보가 표시됩니다.</p>
         </div>
       </aside>
     );
   }
 
   return (
-    <aside className={styles.panel}>
-      {selectedNode.type === "document" && (
+    <aside className={panelClass}>
+      <div className={styles.dragHandle}>
+        <div className={styles.dragHandleBar} />
+      </div>
+      {selectedNode.type === 'document' && (
         <DocumentInspector data={selectedNode.data as DocumentNodeData} />
       )}
-      {selectedNode.type === "image" && (
+      {selectedNode.type === 'image' && (
         <ImageInspector data={selectedNode.data as ImageNodeData} />
       )}
-      {selectedNode.type === "note" && (
-        <NoteInspector
-          id={selectedNode.id}
-          data={selectedNode.data as NoteNodeData}
-        />
+      {selectedNode.type === 'note' && (
+        <NoteInspector id={selectedNode.id} data={selectedNode.data as NoteNodeData} />
       )}
     </aside>
   );

--- a/src/pages/CanvasPage/CanvasPage.module.scss
+++ b/src/pages/CanvasPage/CanvasPage.module.scss
@@ -1,3 +1,5 @@
+@use '../../shared/styles/mixins' as *;
+
 .page {
   width: 100%;
   height: 100%;

--- a/src/pages/LoginPage/LoginPage.module.scss
+++ b/src/pages/LoginPage/LoginPage.module.scss
@@ -1,66 +1,162 @@
+@use '../../shared/styles/mixins' as *;
+
 .page {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100dvh;
   background: var(--color-bg-app);
+  padding: var(--space-4);
+
+  @include sm {
+    padding: var(--space-6);
+  }
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+
+.brandMark {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.brandName {
+  font-family: var(--font-display);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  letter-spacing: var(--letter-spacing-tight);
 }
 
 .card {
   width: 100%;
   max-width: 400px;
-  padding: var(--space-8);
+  padding: var(--space-6);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+
+  @include sm {
+    padding: var(--space-8);
+  }
+}
+
+.titleBlock {
+  margin-bottom: var(--space-8);
 }
 
 .title {
+  font-family: var(--font-display);
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  margin-bottom: var(--space-6);
   text-align: center;
+  letter-spacing: var(--letter-spacing-tight);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-5);
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
+}
+
+.fieldHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-caps);
+}
+
+.inputWrapper {
+  position: relative;
+}
+
+.inputIcon {
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+  flex-shrink: 0;
 }
 
 .input {
+  width: 100%;
   padding: var(--space-3) var(--space-4);
-  font-size: var(--font-size-md);
+  padding-left: calc(var(--space-3) + 18px + var(--space-2));
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
-  background: var(--color-bg-sunken);
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
   outline: none;
-  transition: border-color var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--color-text-tertiary);
+  }
 
   &:focus {
     border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+  }
+}
+
+.inputToggle {
+  position: absolute;
+  right: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: var(--color-text-secondary);
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
   }
 }
 
 .error {
   font-size: var(--font-size-sm);
   color: var(--color-error);
-  margin-top: var(--space-1);
 }
 
 .submitButton {
@@ -68,15 +164,22 @@
   padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-text-inverse);
+  color: #ffffff;
   background: var(--color-interactive-primary);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    transform var(--transition-fast);
+  width: 100%;
 
   &:hover:not(:disabled) {
     background: var(--color-interactive-primary-hover);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
   }
 
   &:disabled {
@@ -85,18 +188,22 @@
   }
 }
 
-.footer {
-  margin-top: var(--space-6);
+.cardFooter {
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border-subtle);
   text-align: center;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
 .link {
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-link);
   text-decoration: none;
+  margin-left: var(--space-1);
 
   &:hover {
-    text-decoration: underline;
+    color: var(--color-interactive-primary-hover);
   }
 }

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -4,12 +4,66 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useLogin } from '../../features/auth/hooks/useLogin';
 import styles from './LoginPage.module.scss';
 
+const MailIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="m2 7 10 7 10-7" />
+  </svg>
+);
+
+const LockIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="5" y="11" width="14" height="10" rx="2" />
+    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+  </svg>
+);
+
+const EyeIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const EyeOffIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+    <line x1="1" y1="1" x2="23" y2="23" />
+  </svg>
+);
+
 export const LoginPage = () => {
   const navigate = useNavigate();
   const { mutate: login, isPending, error } = useLogin();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -23,48 +77,82 @@ export const LoginPage = () => {
 
   return (
     <div className={styles.page}>
+      <div className={styles.brand}>
+        <img src="/logo.svg" alt="" className={styles.brandMark} aria-hidden="true" />
+        <span className={styles.brandName}>CastCanvas Lab</span>
+      </div>
+
       <div className={styles.card}>
-        <h1 className={styles.title}>로그인</h1>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>로그인</h1>
+        </div>
+
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.field}>
             <label className={styles.label} htmlFor="email">
               이메일
             </label>
-            <input
-              id="email"
-              className={styles.input}
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              autoComplete="email"
-            />
+            <div className={styles.inputWrapper}>
+              <span className={styles.inputIcon}>
+                <MailIcon />
+              </span>
+              <input
+                id="email"
+                className={styles.input}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="example@email.com"
+                required
+                autoComplete="email"
+              />
+            </div>
           </div>
+
           <div className={styles.field}>
-            <label className={styles.label} htmlFor="password">
-              비밀번호
-            </label>
-            <input
-              id="password"
-              className={styles.input}
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="current-password"
-            />
+            <div className={styles.fieldHeader}>
+              <label className={styles.label} htmlFor="password">
+                비밀번호
+              </label>
+            </div>
+            <div className={styles.inputWrapper}>
+              <span className={styles.inputIcon}>
+                <LockIcon />
+              </span>
+              <input
+                id="password"
+                className={styles.input}
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                required
+                autoComplete="current-password"
+              />
+              <button
+                type="button"
+                className={styles.inputToggle}
+                onClick={() => setShowPassword((prev) => !prev)}
+                aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+              >
+                {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+              </button>
+            </div>
           </div>
+
           {error && <p className={styles.error}>{error.message}</p>}
+
           <button className={styles.submitButton} type="submit" disabled={isPending}>
             {isPending ? '로그인 중...' : '로그인'}
           </button>
         </form>
-        <p className={styles.footer}>
-          계정이 없으신가요?{' '}
+
+        <div className={styles.cardFooter}>
+          계정이 없으신가요?
           <Link className={styles.link} to="/signup">
             회원가입
           </Link>
-        </p>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/SignupPage/SignupPage.module.scss
+++ b/src/pages/SignupPage/SignupPage.module.scss
@@ -1,66 +1,137 @@
+@use '../../shared/styles/mixins' as *;
+
 .page {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100dvh;
   background: var(--color-bg-app);
+  padding: var(--space-4);
+
+  @include sm {
+    padding: var(--space-6);
+  }
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+
+.brandMark {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.brandName {
+  font-family: var(--font-display);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  letter-spacing: var(--letter-spacing-tight);
 }
 
 .card {
   width: 100%;
   max-width: 400px;
-  padding: var(--space-8);
+  padding: var(--space-6);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+
+  @include sm {
+    padding: var(--space-8);
+  }
+}
+
+.titleBlock {
+  margin-bottom: var(--space-8);
 }
 
 .title {
+  font-family: var(--font-display);
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  margin-bottom: var(--space-6);
-  text-align: center;
+  letter-spacing: var(--letter-spacing-tight);
+  margin-bottom: var(--space-1);
+}
+
+.subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-2);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-5);
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
 }
 
 .label {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+.inputWrapper {
+  position: relative;
+}
+
+.inputIcon {
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+  flex-shrink: 0;
 }
 
 .input {
+  width: 100%;
   padding: var(--space-3) var(--space-4);
-  font-size: var(--font-size-md);
+  padding-left: calc(var(--space-3) + 18px + var(--space-2));
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
-  background: var(--color-bg-sunken);
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
   outline: none;
-  transition: border-color var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--color-text-tertiary);
+  }
 
   &:focus {
     border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
   }
 }
 
 .error {
   font-size: var(--font-size-sm);
   color: var(--color-error);
-  margin-top: var(--space-1);
 }
 
 .submitButton {
@@ -68,15 +139,22 @@
   padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-text-inverse);
+  color: #ffffff;
   background: var(--color-interactive-primary);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    transform var(--transition-fast);
+  width: 100%;
 
   &:hover:not(:disabled) {
     background: var(--color-interactive-primary-hover);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
   }
 
   &:disabled {
@@ -85,18 +163,22 @@
   }
 }
 
-.footer {
-  margin-top: var(--space-6);
+.cardFooter {
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border-subtle);
   text-align: center;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
 .link {
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-link);
   text-decoration: none;
+  margin-left: var(--space-1);
 
   &:hover {
-    text-decoration: underline;
+    color: var(--color-interactive-primary-hover);
   }
 }

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -4,6 +4,45 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useSignup } from '../../features/auth/hooks/useSignup';
 import styles from './SignupPage.module.scss';
 
+const PersonIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="12" cy="8" r="4" />
+    <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+  </svg>
+);
+
+const MailIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="m2 7 10 7 10-7" />
+  </svg>
+);
+
+const LockIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="5" y="11" width="14" height="10" rx="2" />
+    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+  </svg>
+);
+
 export const SignupPage = () => {
   const navigate = useNavigate();
   const { mutate: signup, isPending, error } = useSignup();
@@ -24,62 +63,94 @@ export const SignupPage = () => {
 
   return (
     <div className={styles.page}>
+      <div className={styles.brand}>
+        <img src="/logo.svg" alt="" className={styles.brandMark} aria-hidden="true" />
+        <span className={styles.brandName}>CastCanvas Lab</span>
+      </div>
+
       <div className={styles.card}>
-        <h1 className={styles.title}>회원가입</h1>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>회원가입</h1>
+          <p className={styles.subtitle}>CastCanvas Lab과 함께 창의적인 여정을 시작하세요.</p>
+        </div>
+
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.field}>
             <label className={styles.label} htmlFor="nickname">
               닉네임
             </label>
-            <input
-              id="nickname"
-              className={styles.input}
-              type="text"
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-              required
-              autoComplete="nickname"
-            />
+            <div className={styles.inputWrapper}>
+              <span className={styles.inputIcon}>
+                <PersonIcon />
+              </span>
+              <input
+                id="nickname"
+                className={styles.input}
+                type="text"
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder="사용하실 닉네임을 입력하세요"
+                required
+                autoComplete="nickname"
+              />
+            </div>
           </div>
+
           <div className={styles.field}>
             <label className={styles.label} htmlFor="email">
               이메일
             </label>
-            <input
-              id="email"
-              className={styles.input}
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              autoComplete="email"
-            />
+            <div className={styles.inputWrapper}>
+              <span className={styles.inputIcon}>
+                <MailIcon />
+              </span>
+              <input
+                id="email"
+                className={styles.input}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="example@email.com"
+                required
+                autoComplete="email"
+              />
+            </div>
           </div>
+
           <div className={styles.field}>
             <label className={styles.label} htmlFor="password">
               비밀번호
             </label>
-            <input
-              id="password"
-              className={styles.input}
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="new-password"
-            />
+            <div className={styles.inputWrapper}>
+              <span className={styles.inputIcon}>
+                <LockIcon />
+              </span>
+              <input
+                id="password"
+                className={styles.input}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="8자 이상의 영문, 숫자 조합"
+                required
+                autoComplete="new-password"
+              />
+            </div>
           </div>
+
           {error && <p className={styles.error}>{error.message}</p>}
+
           <button className={styles.submitButton} type="submit" disabled={isPending}>
             {isPending ? '가입 중...' : '회원가입'}
           </button>
         </form>
-        <p className={styles.footer}>
-          이미 계정이 있으신가요?{' '}
+
+        <div className={styles.cardFooter}>
+          이미 계정이 있으신가요?
           <Link className={styles.link} to="/login">
             로그인
           </Link>
-        </p>
+        </div>
       </div>
     </div>
   );

--- a/src/shared/styles/_mixins.scss
+++ b/src/shared/styles/_mixins.scss
@@ -2,6 +2,49 @@
 // Mixins — CastCanvas Lab
 // =============================================================================
 
+// Breakpoints
+// sm: 480px  — large mobile
+// md: 768px  — tablet
+// lg: 1024px — desktop
+// xl: 1280px — wide desktop
+
+@mixin sm {
+  @media (min-width: 480px) {
+    @content;
+  }
+}
+
+@mixin md {
+  @media (min-width: 768px) {
+    @content;
+  }
+}
+
+@mixin lg {
+  @media (min-width: 1024px) {
+    @content;
+  }
+}
+
+@mixin xl {
+  @media (min-width: 1280px) {
+    @content;
+  }
+}
+
+// max-width variants (mobile-first overrides)
+@mixin below-sm {
+  @media (max-width: 479px) {
+    @content;
+  }
+}
+
+@mixin below-md {
+  @media (max-width: 767px) {
+    @content;
+  }
+}
+
 // Focus ring — consistent keyboard focus style
 @mixin focus-ring {
   outline: 2px solid var(--color-border-focus);

--- a/src/shared/styles/_tokens.scss
+++ b/src/shared/styles/_tokens.scss
@@ -53,7 +53,7 @@
 // -----------------------------------------------------------------------------
 :root {
   // Surface
-  --color-bg-app: var(--palette-neutral-100);
+  --color-bg-app: var(--palette-neutral-50);
   --color-bg-surface: var(--palette-neutral-0);
   --color-bg-elevated: var(--palette-neutral-0);
   --color-bg-sunken: var(--palette-neutral-50);
@@ -104,12 +104,9 @@
 
   // Shadow
   --shadow-sm: 0 1px 2px rgba(15, 18, 32, 0.07);
-  --shadow-md:
-    0 4px 8px rgba(15, 18, 32, 0.09), 0 1px 2px rgba(15, 18, 32, 0.06);
-  --shadow-lg:
-    0 8px 24px rgba(15, 18, 32, 0.11), 0 2px 8px rgba(15, 18, 32, 0.07);
-  --shadow-xl:
-    0 16px 48px rgba(15, 18, 32, 0.14), 0 4px 16px rgba(15, 18, 32, 0.09);
+  --shadow-md: 0 4px 8px rgba(15, 18, 32, 0.09), 0 1px 2px rgba(15, 18, 32, 0.06);
+  --shadow-lg: 0 8px 24px rgba(15, 18, 32, 0.11), 0 2px 8px rgba(15, 18, 32, 0.07);
+  --shadow-xl: 0 16px 48px rgba(15, 18, 32, 0.14), 0 4px 16px rgba(15, 18, 32, 0.09);
 }
 
 // -----------------------------------------------------------------------------
@@ -173,13 +170,13 @@
 }
 
 // Explicit dark mode (user preference)
-[data-theme="dark"] {
+[data-theme='dark'] {
   @include dark-tokens;
 }
 
 // System dark mode (no explicit user preference set)
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+  :root:not([data-theme='light']):not([data-theme='dark']) {
     @include dark-tokens;
   }
 }

--- a/src/shared/styles/_typography.scss
+++ b/src/shared/styles/_typography.scss
@@ -4,11 +4,10 @@
 
 :root {
   // Font families
+  --font-display: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-sans:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
-    Arial, sans-serif;
-  --font-mono:
-    "JetBrains Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
+    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
 
   // Font sizes
   --font-size-xs: 0.6875rem; // 11px

--- a/tasks/SITE_FE_BRAND_GUIDE.md
+++ b/tasks/SITE_FE_BRAND_GUIDE.md
@@ -1,0 +1,81 @@
+# CastCanvas Lab — Site → FE 브랜드 정렬 가이드
+
+> 이 문서는 `cast-canvas-lab-site`에서 확정된 브랜드 기준을 FE 앱에 이식하는 기준 문서다.
+> 원본 기준: `cast-canvas-lab-site/STATUS.md` "FE 이식 요소" 섹션 (SITE 이슈 #4, ORCH 에픽 #8)
+> Stitch 프로젝트: `projects/13423040029133228893` (CastCanvas Lab — App UI)
+
+---
+
+## 확정된 브랜드 토큰
+
+| 요소           | 값                     | FE 토큰                                         |
+| -------------- | ---------------------- | ----------------------------------------------- |
+| Primary color  | `#4f46e5` (Indigo 600) | `--color-interactive-primary`                   |
+| Headline font  | Plus Jakarta Sans      | `--font-display`                                |
+| Body font      | Inter                  | `--font-sans`                                   |
+| Border radius  | 8px                    | `--radius-md`                                   |
+| App background | `#f7f8fc` (neutral-50) | `--color-bg-app`                                |
+| Card surface   | `#ffffff` + 1px border | `--color-bg-surface` + `--color-border-default` |
+| Button primary | Indigo fill, semibold  | `--color-interactive-primary`                   |
+| Icon style     | Thin stroke, 18–24px   | inline SVG                                      |
+
+---
+
+## 적용 원칙
+
+### 앱 vs. site 밀도 차이
+
+- site는 마케팅 랜딩 → 여백 넓고 장식적
+- FE 앱은 캔버스 중심 → 정보 밀도 높고 절제된 브랜드 요소
+- 같은 브랜드 컬러/폰트를 쓰되, 레이아웃·애니메이션은 site를 그대로 복제하지 않는다
+
+### 폰트 사용 기준
+
+- `--font-display` (Plus Jakarta Sans): 페이지 타이틀, 브랜드명, 카드 제목 등 헤드라인
+- `--font-sans` (Inter): 본문, 라벨, 버튼, 인풋 등 모든 UI 텍스트
+
+### 브랜드 로고마크
+
+- Indigo `--radius-sm` 정사각형 + Layers 아이콘 (filled, white)
+- 인증 페이지: 카드 외부 상단 중앙 배치
+- 툴바: 좌측 28px 마크만 표시 (텍스트 없음)
+
+### 인터랙티브 요소 기준
+
+- 버튼: `--radius-md`, Indigo fill, semibold, `active:scale(0.98)`
+- 인풋: `--radius-md`, 1px border, focus ring `rgba(99,102,241,0.12)`
+- 카드: `--radius-md`, 1px border, `--shadow-sm`
+
+---
+
+## 화면별 적용 현황
+
+| 화면              | 상태  | 비고                                                                    |
+| ----------------- | ----- | ----------------------------------------------------------------------- |
+| 로그인 페이지     | `[x]` | 브랜드 로고마크, Plus Jakarta Sans 타이틀, 아이콘 인풋, visibility 토글 |
+| 회원가입 페이지   | `[x]` | 로그인과 동일 패턴, 서브타이틀 추가                                     |
+| 캔버스 Toolbar    | `[x]` | full-width top bar, 브랜드마크, 아이콘 버튼                             |
+| 캔버스 노드       | `[~]` | 기존 토큰 기반 — 추가 조정 불필요                                       |
+| Inspector 패널    | `[~]` | 기존 토큰 기반 — 추가 조정 불필요                                       |
+| 워크스페이스 목록 | `[ ]` | FE 이슈 #21 구현 시 이 가이드 기준 적용                                 |
+
+---
+
+## Stitch 참조
+
+- 프로젝트: `projects/13423040029133228893`
+- 디자인 시스템: `assets/17329504999202418113`
+- 생성된 화면:
+  - 로그인: `screens/919e4fc3c78743c1b0f96acc8f40d353`
+  - 회원가입: `screens/0cde661a6b434e018c04c28c9d81a157`
+- 캔버스 화면: 타임아웃으로 미생성 — 추후 재시도 또는 코드 직접 구현
+
+---
+
+## 다음 화면 작업 시 참고 프롬프트 패턴
+
+```
+CastCanvas Lab [화면명]. [레이아웃 설명].
+Brand: Indigo #4f46e5, Plus Jakarta Sans bold headlines, Inter body, 8px radius, #f7f8fc background, white cards with 1px border.
+Clean app UI, high information density, no decorative elements.
+```


### PR DESCRIPTION
## Summary

- ORCH 에픽 #8 / SITE 이슈 #4에서 확정된 브랜드 기준(Indigo #4f46e5, Plus Jakarta Sans, 8px radius, #f7f8fc bg)을 FE 앱 UI에 이식
- Google Stitch MCP로 로그인/회원가입 화면 초안 생성 후 FE 코드에 반영
- 반응형 브레이크포인트 믹스인 추가 및 전체 화면 반응형 처리

## Changes

### 디자인 토큰
- `--font-display` (Plus Jakarta Sans) 토큰 추가, Google Fonts 로딩
- `--color-bg-app` → `neutral-50` (#f7f8fc) — site와 통일
- `_mixins.scss` sm/md/lg/xl 브레이크포인트 믹스인 추가

### 인증 페이지 (로그인 / 회원가입)
- 브랜드 로고마크 (`/logo.svg`) + "CastCanvas Lab" 헤드라인 추가
- 아이콘 prefix 인풋 (Mail, Lock, Person)
- 비밀번호 visibility 토글
- 카드 footer border-top 구분선
- 반응형: 모바일 패딩 축소

### Toolbar
- 좌측 브랜드마크 + 아이콘 버튼 구조로 개선
- 반응형: 모바일 텍스트 레이블 숨김, md 이상 유저명 표시

### Inspector 패널
- 모바일: `position: fixed` bottom sheet (노드 선택 시 슬라이드 업)
- 데스크탑: 기존 우측 320px 패널 유지

### 브랜드 일관성
- 로고마크: site favicon(`icon.svg`) 동일 파일 사용
- 브랜드명 weight/색상 site Header와 동일하게 맞춤
- 아이콘 스타일: thin stroke, fill none — site와 동일

### 문서
- `tasks/SITE_FE_BRAND_GUIDE.md` — 브랜드 정렬 기준 및 Stitch 프로젝트 참조 문서 추가

## Test plan

- [ ] 로그인 페이지 — 브랜드마크, 폰트, 인풋 아이콘, 버튼 스타일 확인
- [ ] 회원가입 페이지 — 로그인과 동일 톤 확인
- [ ] 모바일(< 480px) — 인증 페이지 패딩, Toolbar 아이콘만 표시 확인
- [ ] 모바일에서 캔버스 노드 선택 시 Inspector bottom sheet 슬라이드 업 확인
- [ ] 데스크탑(≥ 768px) — Inspector 우측 패널 정상 표시 확인
- [ ] 브라우저 탭 favicon이 Indigo 로고마크로 표시되는지 확인
- [ ] 다크모드 — 토큰 기반 색상 정상 동작 확인

Closes #22

Made with [Cursor](https://cursor.com)